### PR TITLE
add signup page

### DIFF
--- a/app/public/css/pages/signup.css
+++ b/app/public/css/pages/signup.css
@@ -1,0 +1,71 @@
+.signup_container {
+  width: 600px;
+  max-width: 600px;
+  margin: 100px auto;
+  text-align: center;
+}
+
+.signup_title {
+  font-size: 50px;
+  font-weight: bold;
+  letter-spacing: 10px;
+  margin-bottom: 100px;
+}
+
+.signup_username_label, .signup_email_label, .signup_password_label {
+  display: block;
+  font-size: 22px;
+  letter-spacing: 1.2rem;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.signup_username_input, .signup_email_input, .signup_password_input {
+  display: block;
+  background: #EDEDED;
+  margin: 0 auto;
+  border-radius: 40px;
+  width: 600px;
+  height: 60px;
+  font-size: 20px;
+  padding: 0 30px;
+  font-weight: bold;
+  letter-spacing: 2px;
+}
+
+.signup_username_input:focus, .signup_email_input:focus, .signup_password_input:focus {
+  outline: #8A8A8A 2px solid;
+} 
+
+.signup_form {
+  margin-bottom: 50px;
+}
+
+.signup_username_container, .signup_email_container, .signup_password_container {
+  text-align: left;
+  padding-bottom: 50px;
+}
+
+.signup_message {
+  font-size: 20px;
+  letter-spacing: 2px;
+  font-weight: bold;
+  color: #e82401;
+}
+
+.signup_button_container {
+  width: 250px;
+  height: 70px;
+  margin: 50px auto;
+}
+
+.signup_button {
+  display: block;
+  width: 250px;
+  height: 70px;
+  background: #e82401;
+  color: #fff;
+  border-radius: 10px;
+  font-size: 18px;
+  font-weight: bold;
+}

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -1,3 +1,4 @@
 @import url("./reset.css");
 @import url("./pages/header.css");
 @import url("./pages/login.css");
+@import url("./pages/signup.css");

--- a/app/public/module/signup.js
+++ b/app/public/module/signup.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const signup_form = document.getElementById('signup_form');
+  // const signupMessage = document.getElementById('signup_message');
+
+  signup_form.addEventListener('submit', async function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    const formData = new FormData(signup_form);
+
+    try {
+      const response = await fetch('/api/signup', {
+        method: 'POST',
+        body: formData
+      });
+
+      if (!response.ok) {
+        const responseData = await response.json();
+        data = JSON.parse(JSON.stringify(responseData, null, 2))
+        console.log(data)
+        throw new Error('Network response was not ok');
+      } else {
+        window.location.href = "/";
+      }
+
+      // レスポンスを表示または処理する
+    } catch (error) {
+      console.error('Fetch error:', error);
+    }
+  });
+});

--- a/app/public/signup.html.erb
+++ b/app/public/signup.html.erb
@@ -1,0 +1,29 @@
+<%= ERB.new(File.read('./public/components/header.html.erb'), nil, nil, '_footer_out').result(binding) %>
+
+<main class="signup_container">
+  <h1 class="signup_title">LIQ+RECIPE<br>アカウント作成</h1>
+  <form action="/api/signup" method="post" id="signup_form" class="signup_form">
+      <div class="signup_username_container">
+        <label class="signup_username_label" for="username">ユーザーネーム（必須）</label>
+        <input class="signup_username_input" type="text" id="username" name="username" autocomplete="off" required>
+      </div>
+      <div class="signup_email_container">
+        <label class="signup_email_label" for="email">メールアドレス（必須）</label>
+        <input class="signup_email_input" type="email" id="email" name="email" autocomplete="off" placeholder="mail@liq-recipe.com" required>
+      </div>
+      <div class="signup_password_container">
+        <label class="signup_password_label" for="password">パスワード（必須）</label>
+        <input class="signup_password_input" type="password" id="password" name="password"  autocomplete="off" required>
+      </div>
+      <div class="signup_password_container">
+        <label class="signup_password_label" for="password_confirm">パスワード確認（必須）</label>
+        <input class="signup_password_input" type="password" id="password_confirm" name="password_confirm"  autocomplete="off" required>
+      </div>
+      <div class="signup_message" id="signup_message"></div>
+      <div class="signup_button_container">
+      <input class="signup_button" type="submit" value="ユーザー登録">
+      </div>
+    </form>
+</main>
+
+<%= ERB.new(File.read('./public/components/footer.html.erb'), nil, nil, '_footer_out').result(binding) %>


### PR DESCRIPTION
ユーザー登録画面を追加
- ユーザーネーム、メールアドレス、パスワードをデータベースに保存
- 登録済みの場合はエラーを出す
- ユーザーアイコンは5種類からランダムで選択

今後追加予定
- パスワードのハッシュ化（現在はデバック時などで必要になりそうなので、ハッシュ化せずそのままDBに保存）
- パスワード確認欄は現在入力チェックのみ。バリデーション機能追加時に、パスワードが一致しているかチェックさせる。
- ユーザー登録後の遷移先画面を、レシピ一覧画面が完成したら、そちらに切り替える。